### PR TITLE
Fix auto-generated collection name for Document

### DIFF
--- a/bosc/document.py
+++ b/bosc/document.py
@@ -36,7 +36,7 @@ class Document(BaseModel, metaclass=CombinedMeta):
     @classmethod
     def get_collection(cls) -> Collection:
         if cls.bosc_collection_name is None:
-            return cls.get_database()[cls.__class__.__name__]
+            return cls.get_database()[cls.__name__]
         return cls.get_database()[cls.bosc_collection_name]
 
     @classmethod

--- a/tests/document/test_collection_name.py
+++ b/tests/document/test_collection_name.py
@@ -1,0 +1,27 @@
+from bosc import Document
+
+
+class SampleWithoutCollection(Document):
+    name: str
+    age: int
+
+    bosc_database_path = "test_db"
+
+
+class SampleWithCollection(SampleWithoutCollection):
+    bosc_collection_name = "test_collection"
+
+
+class TestCollectionName:
+    def test_collection_name_none(self):
+        sample = SampleWithoutCollection(name="John", age=25)
+        assert sample.bosc_collection_name is None
+        assert (
+            sample.get_collection().collection_name
+            == SampleWithoutCollection.__name__
+        )
+
+    def test_collection_name_populated(self):
+        sample = SampleWithCollection(name="John", age=25)
+        assert sample.bosc_collection_name == "test_collection"
+        assert sample.get_collection().collection_name == "test_collection"


### PR DESCRIPTION
When `Document` is created without `bosc_collection_name`, the auto-generated collection name was getting set to `'CombinedMeta'` instead of the Document class's name.